### PR TITLE
Fix race in fileToBase64 setup

### DIFF
--- a/all-model-chat/utils/domainUtils.ts
+++ b/all-model-chat/utils/domainUtils.ts
@@ -6,7 +6,6 @@ import { logService } from '../services/logService';
 export const fileToBase64 = (file: File): Promise<string> => {
     return new Promise((resolve, reject) => {
         const reader = new FileReader();
-        reader.readAsDataURL(file);
         reader.onload = () => {
             const result = reader.result as string;
             const base64Data = result.split(',')[1];
@@ -17,6 +16,7 @@ export const fileToBase64 = (file: File): Promise<string> => {
             }
         };
         reader.onerror = error => reject(error);
+        reader.readAsDataURL(file);
     });
 };
 


### PR DESCRIPTION
## Summary
- ensure FileReader event handlers are set before reading data in `fileToBase64`

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689553b7b01c83209486d4e5c72abf1c