### PR TITLE
fix: fix the missing imageSize parameter when generating images. (#28)

### DIFF
--- a/all-model-chat/hooks/chat/useChat.ts
+++ b/all-model-chat/hooks/chat/useChat.ts
@@ -85,7 +85,7 @@ export const useChat = (appSettings: AppSettings, setAppSettings: React.Dispatch
     const messageHandler = useMessageHandler({ 
         appSettings, messages, isLoading, currentChatSettings, selectedFiles, 
         setSelectedFiles, editingMessageId, setEditingMessageId, setEditMode, setAppFileError, 
-        aspectRatio, userScrolledUp, ttsMessageId, setTtsMessageId, activeSessionId, 
+        aspectRatio, imageSize, userScrolledUp, ttsMessageId, setTtsMessageId, activeSessionId, 
         setActiveSessionId, setCommandedInput, activeJobs, loadingSessionIds, 
         setLoadingSessionIds, updateAndPersistSessions, language, 
         scrollContainerRef: scrollHandler.scrollContainerRef,

--- a/all-model-chat/hooks/useMessageHandler.ts
+++ b/all-model-chat/hooks/useMessageHandler.ts
@@ -20,6 +20,7 @@ interface MessageHandlerProps {
     setEditMode: (mode: 'update' | 'resend') => void;
     setAppFileError: (error: string | null) => void;
     aspectRatio: string;
+    imageSize?: string;
     userScrolledUp: React.MutableRefObject<boolean>;
     ttsMessageId: string | null;
     setTtsMessageId: (id: string | null) => void;


### PR DESCRIPTION
修复imageSize参数丢失

当使用Nano Banana Pro生成图片时，切换生成图片大小功能不生效，一直是默认的1K分辨率图片 · Issue #28 · yeahhe365/All-Model-Chat
https://github.com/yeahhe365/All-Model-Chat/issues/28

